### PR TITLE
Merge pcaps on Dalton Conroller instead of the Agent.

### DIFF
--- a/app/static/engine-configs/snort/snort-2.9.7.0.conf
+++ b/app/static/engine-configs/snort/snort-2.9.7.0.conf
@@ -541,7 +541,7 @@ include /etc/snort/reference.config
 # NOTE: All categories are enabled in this conf file
 ###################################################
 
-# site specific rules
+# added when job is run
 #include $RULE_PATH/local.rules
 
 #include $RULE_PATH/app-detect.rules

--- a/app/static/engine-configs/suricata/suricata-3.0.yaml
+++ b/app/static/engine-configs/suricata/suricata-3.0.yaml
@@ -1122,58 +1122,59 @@ ipfw:
 
 # Set the default rule path here to search for the files.
 # if not set, it will look at the current working dir
-default-rule-path: /etc/suricata/rules
-rule-files:
- - botcc.rules
- - ciarmy.rules
- - compromised.rules
- - drop.rules
- - dshield.rules
- - emerging-activex.rules
- - emerging-attack_response.rules
- - emerging-chat.rules
- - emerging-current_events.rules
- - emerging-dns.rules
- - emerging-dos.rules
- - emerging-exploit.rules
- - emerging-ftp.rules
- - emerging-games.rules
- - emerging-icmp_info.rules
-# - emerging-icmp.rules
- - emerging-imap.rules
- - emerging-inappropriate.rules
- - emerging-malware.rules
- - emerging-misc.rules
- - emerging-mobile_malware.rules
- - emerging-netbios.rules
- - emerging-p2p.rules
- - emerging-policy.rules
- - emerging-pop3.rules
- - emerging-rpc.rules
- - emerging-scada.rules
- - emerging-scan.rules
- - emerging-shellcode.rules
- - emerging-smtp.rules
- - emerging-snmp.rules
- - emerging-sql.rules
- - emerging-telnet.rules
- - emerging-tftp.rules
- - emerging-trojan.rules
- - emerging-user_agents.rules
- - emerging-voip.rules
- - emerging-web_client.rules
- - emerging-web_server.rules
- - emerging-web_specific_apps.rules
- - emerging-worm.rules
- - tor.rules
- - decoder-events.rules # available in suricata sources under rules dir
- - stream-events.rules  # available in suricata sources under rules dir
- - http-events.rules    # available in suricata sources under rules dir
- - smtp-events.rules    # available in suricata sources under rules dir
- - dns-events.rules     # available in suricata sources under rules dir
- - tls-events.rules     # available in suricata sources under rules dir
-# - modbus-events.rules  # available in suricata sources under rules dir
- - app-layer-events.rules  # available in suricata sources under rules dir
+# added when job is run
+#default-rule-path: /etc/suricata/rules
+#rule-files:
+# - botcc.rules
+# - ciarmy.rules
+# - compromised.rules
+# - drop.rules
+# - dshield.rules
+# - emerging-activex.rules
+# - emerging-attack_response.rules
+# - emerging-chat.rules
+# - emerging-current_events.rules
+# - emerging-dns.rules
+# - emerging-dos.rules
+# - emerging-exploit.rules
+# - emerging-ftp.rules
+# - emerging-games.rules
+# - emerging-icmp_info.rules
+## - emerging-icmp.rules
+# - emerging-imap.rules
+# - emerging-inappropriate.rules
+# - emerging-malware.rules
+# - emerging-misc.rules
+# - emerging-mobile_malware.rules
+# - emerging-netbios.rules
+# - emerging-p2p.rules
+# - emerging-policy.rules
+# - emerging-pop3.rules
+# - emerging-rpc.rules
+# - emerging-scada.rules
+# - emerging-scan.rules
+## - emerging-shellcode.rules
+# - emerging-smtp.rules
+# - emerging-snmp.rules
+# - emerging-sql.rules
+# - emerging-telnet.rules
+# - emerging-tftp.rules
+# - emerging-trojan.rules
+# - emerging-user_agents.rules
+# - emerging-voip.rules
+# - emerging-web_client.rules
+# - emerging-web_server.rules
+# - emerging-web_specific_apps.rules
+# - emerging-worm.rules
+# - tor.rules
+# - decoder-events.rules # available in suricata sources under rules dir
+# - stream-events.rules  # available in suricata sources under rules dir
+# - http-events.rules    # available in suricata sources under rules dir
+# - smtp-events.rules    # available in suricata sources under rules dir
+# - dns-events.rules     # available in suricata sources under rules dir
+# - tls-events.rules     # available in suricata sources under rules dir
+## - modbus-events.rules  # available in suricata sources under rules dir
+# - app-layer-events.rules  # available in suricata sources under rules dir
 
 classification-file: /etc/suricata/classification.config
 reference-config-file: /etc/suricata/reference.config

--- a/dalton-agent/Dockerfile_snort-2.9.7.0
+++ b/dalton-agent/Dockerfile_snort-2.9.7.0
@@ -1,13 +1,12 @@
-# Builds Snort 2.9.7.5 Dalton agent using Snort from Ubuntu repos
+# Builds Snort 2.9.7.0 Dalton agent using Snort from Ubuntu repos
 FROM ubuntu:16.04
 MAINTAINER David Wharton
 
-# tcpdump for pcap analysis; not *requried* for
+# tcpdump is for pcap analysis; not *required* for
 #  the agent but nice to have....
-#  should be included in wireshark anyway (see below)
 RUN apt-get update -y && apt-get install -y \
-    python-dev \
-    tcpdump
+    python=2.7.11-1 \
+    tcpdump=4.9.0-1ubuntu1~ubuntu16.04.1
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y snort=2.9.7.0-5
 
@@ -16,13 +15,9 @@ RUN ln -s /usr/lib/snort_dynamicpreprocessor /usr/local/lib/snort_dynamicpreproc
 RUN ln -s /usr/lib/snort_dynamicengine /usr/local/lib/snort_dynamicengine
 RUN ln -s /usr/lib/snort_dynamicrules /usr/local/lib/snort_dynamicrules
 
-RUN apt-get install -y python-pip
-RUN pip install -U pip
-RUN pip install https://github.com/jasonish/py-idstools/archive/master.zip
-
-# wireshark needed for mergecap; statically compiled
-#  mergecap would be smaller but doing this for now
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install wireshark
+#RUN apt-get install -y python-pip
+#RUN pip install -U pip
+#RUN pip install https://github.com/jasonish/py-idstools/archive/master.zip
 
 RUN mkdir -p /opt/dalton-agent/
 

--- a/dalton-agent/Dockerfile_suricata-3.0
+++ b/dalton-agent/Dockerfile_suricata-3.0
@@ -2,22 +2,17 @@
 FROM ubuntu:16.04
 MAINTAINER David Wharton
 
-# tcpdump for pcap analysis; not *requried* for
+# tcpdump is for pcap analysis; not *required* for
 #  the agent but nice to have....
-#  should be included in wireshark anyway (see below)
 RUN apt-get update -y && apt-get install -y \
-    python-dev \
-    tcpdump
+    python=2.7.11-1 \
+    tcpdump=4.9.0-1ubuntu1~ubuntu16.04.1
 
 RUN apt-get install -y suricata=3.0-1
 
-RUN apt-get install -y python-pip
-RUN pip install -U pip
-RUN pip install https://github.com/jasonish/py-idstools/archive/master.zip
-
-# wireshark needed for mergecap; statically compiled
-#  mergecap would be smaller but doing this for now
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install wireshark
+#RUN apt-get install -y python-pip
+#RUN pip install -U pip
+#RUN pip install https://github.com/jasonish/py-idstools/archive/master.zip
 
 RUN mkdir -p /opt/dalton-agent/
 

--- a/dalton-agent/dalton-agent.conf
+++ b/dalton-agent/dalton-agent.conf
@@ -48,10 +48,6 @@ U2_ANALYZER_BINARY = /root/src/u2spewfoo
 #  in the code but it isn't at this point).
 #U2_ANALYZER_BINARY = /usr/local/bin/python2.7 /root/src/u2spewfoo.py
 
-# mergecap binary used to combine pcap files for Suricata
-#  set to 'auto' to have agent find it on startup
-MERGECAP_BINARY = auto
-
 # tcpdump used to analyze pcaps to provide feedback in case the submitter
 #  did something like submit a pcap without a 3WHS
 #  set to 'auto' to have agent find it on startup

--- a/dalton.conf
+++ b/dalton.conf
@@ -34,5 +34,8 @@ teapot_redis_expire = 3720
 # time (seconds) for jobs to run before setting timeout status
 job_run_timeout = 3600
 
-# API Keys valid for Dalton Agents
+# API Keys valid for Dalton Agents (currently not used)
 api_keys = bmV2ZXIgdW5kZXJlc3RpbWF0ZSB5b3VyIG9wcG9uZW50,ZXhwZWN0IHRoZSB1bmV4cGVjdGVk,dGFrZSBpdCBvdXRzaWRl,UGFpbiBkb24ndCBodXJ0
+
+# location of mergecap binary; needed to combine multiple pcaps for Suricata jobs
+mergecap_binary = /usr/bin/mergecap


### PR DESCRIPTION
Suricata can only read a single pcap in pcap read mode
so if multiple pcaps are submitted, then must first be
combined.  Previously this was done on the Agent which
is nice for distributing load if this was heavy laden but
it also add complexity to the Agent and requires it to have
additional programs (mergecap) installed. And given that
wireshark has to be installed (large!) to get mergecap, it
makes sense to just do this on the Controller and keep the
Agents slim and unburdened.