### PR TITLE
if there are no rules, use idstools rulecat to download a set

### DIFF
--- a/dalton.conf
+++ b/dalton.conf
@@ -45,3 +45,7 @@ mergecap_binary = /usr/bin/mergecap
 
 # program that reads the unified2 binary files and outputs text
 u2_analyzer = /usr/local/lib/python2.7/dist-packages/idstools/scripts/u2spewfoo.py
+
+# if rulecat.py (from py-idstools) exists, then Dalton will download rulesets on
+#  startup iff no rulesets exist
+rulecat_script = /usr/local/lib/python2.7/dist-packages/idstools/scripts/rulecat.py


### PR DESCRIPTION
gets the latest ET ruleset for Snort (2.9) and Suricata (1.3)