### PR TITLE
Updated error handling to direct all errors to error.html page.

### DIFF
--- a/app/templates/dalton/error.html
+++ b/app/templates/dalton/error.html
@@ -1,14 +1,17 @@
 {% extends "dalton/layout.html" %}
 {% block body %}
     <div class="row">
+        <div class="alert alert-error">
+            <h2><span>Error!</span></h2>
+        </div>
+        <p/>
         <div class="span9">
-            <h2><span style="color:red;">Error!</span></h2>
-            <br/>
 	    {% if jid != '' %}
 		    <h3>No data for job {{ jid }}</h3>
 	    {% endif %}
-	    <br/>
-	    {{ msg }}
+        {% for line in msg %}
+            <p>{{line}}</p>
+        {% endfor %}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
This way the broswer back button can be used instead of reloading
the submission page with an error message which will overwrite
initial job config options.

Also made (error) msg a list to allow for newlines in output.