### PR TITLE
set werkzeug logger to level 'ERROR' to prevent docker logs from bein…

### DIFF
--- a/run.py
+++ b/run.py
@@ -3,6 +3,7 @@ from flask_cache import Cache
 from flask_compress import Compress
 from app.dalton import dalton_blueprint
 from app.flowsynth import flowsynth_blueprint
+import logging
 
 # create
 daltonfs = Flask(__name__, static_folder='app/static')
@@ -16,6 +17,16 @@ daltonfs.register_blueprint(dalton_blueprint)
 daltonfs.register_blueprint(flowsynth_blueprint, url_prefix='/flowsynth')
 
 daltonfs.debug = True
+
+# Apparently the werkzeug default logger logs every HTTP request
+#  which bubbles up to the root logger and gets output to the
+#  console which ends up in the docker logs.  Since each agent
+#  checks in every second (by default), this can be voluminous
+#  and is superfluous for my current needs.
+try:
+    logging.getLogger("werkzeug").setLevel(logging.ERROR)
+except Exception as e:
+    pass
 
 compress = Compress()
 cache = Cache(daltonfs, config={"CACHE_TYPE": "simple"})


### PR DESCRIPTION
…g polluted