### PR TITLE
don't specify Python 2 version

### DIFF
--- a/dalton-agent/Dockerfiles/Dockerfile_snort
+++ b/dalton-agent/Dockerfiles/Dockerfile_snort
@@ -11,7 +11,7 @@ ARG DAQ_VERSION
 # tcpdump is for pcap analysis; not *required* for
 #  the agent but nice to have....
 RUN apt-get update -y && apt-get install -y \
-    python=2.7.11-1 \
+    python \
     tcpdump \
     build-essential make flex bison \
     libpcap-dev libpcre3-dev \

--- a/dalton-agent/Dockerfiles/Dockerfile_snort-2.9.7.0
+++ b/dalton-agent/Dockerfiles/Dockerfile_snort-2.9.7.0
@@ -5,7 +5,7 @@ MAINTAINER David Wharton
 # tcpdump is for pcap analysis; not *required* for
 #  the agent but nice to have....
 RUN apt-get update -y && apt-get install -y \
-    python=2.7.11-1 \
+    python \
     tcpdump
 
 # for debugging agent

--- a/dalton-agent/Dockerfiles/Dockerfile_suricata
+++ b/dalton-agent/Dockerfiles/Dockerfile_suricata
@@ -7,7 +7,7 @@ ARG SURI_VERSION
 # tcpdump is for pcap analysis; not *required* for
 #  the agent but nice to have....
 RUN apt-get update -y && apt-get install -y \
-    python=2.7.11-1 \
+    python \
     tcpdump \
     libpcre3 libpcre3-dbg libpcre3-dev \
     build-essential autoconf automake libtool libpcap-dev libnet1-dev \


### PR DESCRIPTION
Specifying Python 2.7.11-1 now causes issues because of Python 2.7.12 and other dependencies:

The following packages have unmet dependencies:
 python : PreDepends: python-minimal (= 2.7.11-1) but 2.7.12-1\~16.04 is to be installed
          Depends: libpython-stdlib (= 2.7.11-1) but 2.7.12-1~16.04 is to be installed
E: Unable to correct problems, you have held broken packages.
