### PR TITLE
tweaks to support snort 2.9.12 agent

### DIFF
--- a/dalton-agent/Dockerfiles/Dockerfile_snort
+++ b/dalton-agent/Dockerfiles/Dockerfile_snort
@@ -17,7 +17,7 @@ RUN apt-get update -y && apt-get install -y \
     libpcap-dev libpcre3-dev \
     libcap-ng-dev libdumbnet-dev \
     zlib1g-dev liblzma-dev openssl libssl-dev \
-    libnghttp2-dev && ldconfig
+    libnghttp2-dev libluajit-5.1-dev && ldconfig
 
 # for debugging agent
 #RUN apt-get install -y less nano

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,18 +87,18 @@ services:
 #      - AGENT_DEBUG=${AGENT_DEBUG}
 #    restart: always
 
-# Suricata 3.2.4 from source
-  agent-suricata-3.2.4:
+# Suricata 3.2.5 from source
+  agent-suricata-3.2.5:
     build:
       context: ./dalton-agent
       dockerfile: Dockerfiles/Dockerfile_suricata
       args:
-        - SURI_VERSION=3.2.4
+        - SURI_VERSION=3.2.5
         - http_proxy=${http_proxy}
         - https_proxy=${https_proxy}
         - no_proxy=${no_proxy}
-    image: suricata-3.2.4:latest
-    container_name: suricata-3.2.4
+    image: suricata-3.2.5:latest
+    container_name: suricata-3.2.5
     environment:
       - AGENT_DEBUG=${AGENT_DEBUG}
     restart: always
@@ -180,19 +180,19 @@ services:
 #  fine on it.
 #
 
-# Snort 2.9.11 from source
-  agent-snort-2.9.11:
+# Snort 2.9.12 from source
+  agent-snort-2.9.12:
     build:
       context: ./dalton-agent
       dockerfile: Dockerfiles/Dockerfile_snort
       args:
-        - SNORT_VERSION=2.9.11
+        - SNORT_VERSION=2.9.12
         - DAQ_VERSION=2.0.6
         - http_proxy=${http_proxy}
         - https_proxy=${https_proxy}
         - no_proxy=${no_proxy}
-    image: snort-2.9.11:latest
-    container_name: snort-2.9.11
+    image: snort-2.9.12:latest
+    container_name: snort-2.9.12
     environment:
       - AGENT_DEBUG=${AGENT_DEBUG}
     restart: always


### PR DESCRIPTION
Added docker-compose directives to build Snort 2.9.12.
And apparently OpenAppID is turned on by default now (instead of the other way around like is has been in the past) so added libluajit-5.1-dev to be installed before Snort is built.

