### PR TITLE
Disable Rust support for Suricata Agents

### DIFF
--- a/dalton-agent/Dockerfiles/Dockerfile_suricata
+++ b/dalton-agent/Dockerfiles/Dockerfile_suricata
@@ -12,7 +12,7 @@ RUN apt-get update -y && apt-get install -y \
     libpcre3 libpcre3-dbg libpcre3-dev \
     build-essential autoconf automake libtool libpcap-dev libnet1-dev \
     libyaml-0-2 libyaml-dev zlib1g zlib1g-dev libcap-ng-dev libcap-ng0 \
-    make libmagic-dev libjansson-dev libjansson4 pkg-config rustc cargo
+    make libmagic-dev libjansson-dev libjansson4 pkg-config
 
 # for debugging agent
 #RUN apt-get install -y less nano


### PR DESCRIPTION
Apparently, 'dns-log is not available when Rust is enabled.' Taking out Rust packages on Suricata Agents.