### PR TITLE
disabled checksum verification in Suricata configs

### DIFF
--- a/app/static/engine-configs/suricata/suricata-1.0.2.yaml
+++ b/app/static/engine-configs/suricata/suricata-1.0.2.yaml
@@ -252,7 +252,7 @@ flow-timeouts:
 #     depth: 1048576            # 1 MB reassembly depth
 stream:
   memcap: 33554432
-  checksum_validation: yes
+  checksum_validation: no
   reassembly:
     memcap: 67108864
     depth: 1048576

--- a/app/static/engine-configs/suricata/suricata-1.0.3.yaml
+++ b/app/static/engine-configs/suricata/suricata-1.0.3.yaml
@@ -252,7 +252,7 @@ flow-timeouts:
 #     depth: 1048576            # 1 MB reassembly depth
 stream:
   memcap: 33554432
-  checksum_validation: yes
+  checksum_validation: no
   reassembly:
     memcap: 67108864
     depth: 1048576

--- a/app/static/engine-configs/suricata/suricata-1.1.yaml
+++ b/app/static/engine-configs/suricata/suricata-1.1.yaml
@@ -474,7 +474,7 @@ flow-timeouts:
 #                               # this size
 stream:
   memcap: 33554432              # 32mb
-  checksum_validation: yes      # reject wrong csums
+  checksum_validation: no      # reject wrong csums
   inline: no                    # no inline mode
   reassembly:
     memcap: 67108864            # 64mb for reassembly

--- a/app/static/engine-configs/suricata/suricata-1.2.yaml
+++ b/app/static/engine-configs/suricata/suricata-1.2.yaml
@@ -525,7 +525,7 @@ flow-timeouts:
 
 stream:
   memcap: 32mb
-  checksum_validation: yes      # reject wrong csums
+  checksum_validation: no      # reject wrong csums
   inline: no                    # no inline mode
   reassembly:
     memcap: 64mb

--- a/app/static/engine-configs/suricata/suricata-1.3.1.yaml
+++ b/app/static/engine-configs/suricata/suricata-1.3.1.yaml
@@ -535,7 +535,7 @@ flow-timeouts:
 
 stream:
   memcap: 32mb
-  checksum-validation: yes      # reject wrong csums
+  checksum-validation: no      # reject wrong csums
   inline: no                    # no inline mode
   reassembly:
     memcap: 64mb

--- a/app/static/engine-configs/suricata/suricata-1.3.3.yaml
+++ b/app/static/engine-configs/suricata/suricata-1.3.3.yaml
@@ -535,7 +535,7 @@ flow-timeouts:
 
 stream:
   memcap: 32mb
-  checksum-validation: yes      # reject wrong csums
+  checksum-validation: no      # reject wrong csums
   inline: no                    # no inline mode
   reassembly:
     memcap: 64mb

--- a/app/static/engine-configs/suricata/suricata-1.3.4.yaml
+++ b/app/static/engine-configs/suricata/suricata-1.3.4.yaml
@@ -535,7 +535,7 @@ flow-timeouts:
 
 stream:
   memcap: 32mb
-  checksum-validation: yes      # reject wrong csums
+  checksum-validation: no      # reject wrong csums
   inline: no                    # no inline mode
   reassembly:
     memcap: 64mb

--- a/app/static/engine-configs/suricata/suricata-1.3.6.yaml
+++ b/app/static/engine-configs/suricata/suricata-1.3.6.yaml
@@ -535,7 +535,7 @@ flow-timeouts:
 
 stream:
   memcap: 32mb
-  checksum-validation: yes      # reject wrong csums
+  checksum-validation: no      # reject wrong csums
   inline: no                    # no inline mode
   reassembly:
     memcap: 64mb

--- a/app/static/engine-configs/suricata/suricata-1.3.yaml
+++ b/app/static/engine-configs/suricata/suricata-1.3.yaml
@@ -536,7 +536,7 @@ flow-timeouts:
 
 stream:
   memcap: 32mb
-  checksum-validation: yes      # reject wrong csums
+  checksum-validation: no      # reject wrong csums
   inline: no                    # no inline mode
   reassembly:
     memcap: 64mb

--- a/app/static/engine-configs/suricata/suricata-1.4.1.yaml
+++ b/app/static/engine-configs/suricata/suricata-1.4.1.yaml
@@ -595,7 +595,7 @@ flow-timeouts:
 
 stream:
   memcap: 32mb
-  checksum-validation: yes      # reject wrong csums
+  checksum-validation: no      # reject wrong csums
   inline: auto                  # auto will use inline mode in IPS mode, yes or no set it statically
   reassembly:
     memcap: 64mb

--- a/app/static/engine-configs/suricata/suricata-1.4.yaml
+++ b/app/static/engine-configs/suricata/suricata-1.4.yaml
@@ -588,7 +588,7 @@ flow-timeouts:
 
 stream:
   memcap: 32mb
-  checksum-validation: yes      # reject wrong csums
+  checksum-validation: no      # reject wrong csums
   inline: auto                  # auto will use inline mode in IPS mode, yes or no set it statically
   reassembly:
     memcap: 64mb

--- a/app/static/engine-configs/suricata/suricata-2.0.1.yaml
+++ b/app/static/engine-configs/suricata/suricata-2.0.1.yaml
@@ -877,7 +877,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # For FreeBSD ipfw(8) divert(4) support.
 # Please make sure you have ipfw_load="YES" and ipdivert_load="YES"

--- a/app/static/engine-configs/suricata/suricata-2.0.2.yaml
+++ b/app/static/engine-configs/suricata/suricata-2.0.2.yaml
@@ -894,7 +894,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # For FreeBSD ipfw(8) divert(4) support.
 # Please make sure you have ipfw_load="YES" and ipdivert_load="YES"

--- a/app/static/engine-configs/suricata/suricata-2.0.6.yaml
+++ b/app/static/engine-configs/suricata/suricata-2.0.6.yaml
@@ -894,7 +894,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # For FreeBSD ipfw(8) divert(4) support.
 # Please make sure you have ipfw_load="YES" and ipdivert_load="YES"

--- a/app/static/engine-configs/suricata/suricata-2.0.yaml
+++ b/app/static/engine-configs/suricata/suricata-2.0.yaml
@@ -874,7 +874,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # For FreeBSD ipfw(8) divert(4) support.
 # Please make sure you have ipfw_load="YES" and ipdivert_load="YES"

--- a/app/static/engine-configs/suricata/suricata-3.0.1.yaml
+++ b/app/static/engine-configs/suricata/suricata-3.0.1.yaml
@@ -1094,7 +1094,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # For FreeBSD ipfw(8) divert(4) support.
 # Please make sure you have ipfw_load="YES" and ipdivert_load="YES"

--- a/app/static/engine-configs/suricata/suricata-3.0.2.yaml
+++ b/app/static/engine-configs/suricata/suricata-3.0.2.yaml
@@ -1094,7 +1094,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # For FreeBSD ipfw(8) divert(4) support.
 # Please make sure you have ipfw_load="YES" and ipdivert_load="YES"

--- a/app/static/engine-configs/suricata/suricata-3.0.yaml
+++ b/app/static/engine-configs/suricata/suricata-3.0.yaml
@@ -1094,7 +1094,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # For FreeBSD ipfw(8) divert(4) support.
 # Please make sure you have ipfw_load="YES" and ipdivert_load="YES"

--- a/app/static/engine-configs/suricata/suricata-3.1.1.yaml
+++ b/app/static/engine-configs/suricata/suricata-3.1.1.yaml
@@ -606,7 +606,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # See "Advanced Capture Options" below for more options, including NETMAP
 # and PF_RING.

--- a/app/static/engine-configs/suricata/suricata-3.1.2.yaml
+++ b/app/static/engine-configs/suricata/suricata-3.1.2.yaml
@@ -619,7 +619,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # See "Advanced Capture Options" below for more options, including NETMAP
 # and PF_RING.

--- a/app/static/engine-configs/suricata/suricata-3.1.yaml
+++ b/app/static/engine-configs/suricata/suricata-3.1.yaml
@@ -606,7 +606,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # See "Advanced Capture Options" below for more options, including NETMAP
 # and PF_RING.

--- a/app/static/engine-configs/suricata/suricata-3.2.1.yaml
+++ b/app/static/engine-configs/suricata/suricata-3.2.1.yaml
@@ -638,7 +638,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # See "Advanced Capture Options" below for more options, including NETMAP
 # and PF_RING.

--- a/app/static/engine-configs/suricata/suricata-3.2.4.yaml
+++ b/app/static/engine-configs/suricata/suricata-3.2.4.yaml
@@ -640,7 +640,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # See "Advanced Capture Options" below for more options, including NETMAP
 # and PF_RING.

--- a/app/static/engine-configs/suricata/suricata-3.2.yaml
+++ b/app/static/engine-configs/suricata/suricata-3.2.yaml
@@ -635,7 +635,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # See "Advanced Capture Options" below for more options, including NETMAP
 # and PF_RING.

--- a/app/static/engine-configs/suricata/suricata-4.0.0.yaml
+++ b/app/static/engine-configs/suricata/suricata-4.0.0.yaml
@@ -666,7 +666,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # See "Advanced Capture Options" below for more options, including NETMAP
 # and PF_RING.

--- a/app/static/engine-configs/suricata/suricata-4.0.1.yaml
+++ b/app/static/engine-configs/suricata/suricata-4.0.1.yaml
@@ -667,7 +667,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # See "Advanced Capture Options" below for more options, including NETMAP
 # and PF_RING.

--- a/app/static/engine-configs/suricata/suricata-4.0.3.yaml
+++ b/app/static/engine-configs/suricata/suricata-4.0.3.yaml
@@ -668,7 +668,7 @@ pcap-file:
   #  - auto: suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # See "Advanced Capture Options" below for more options, including NETMAP
 # and PF_RING.

--- a/app/static/engine-configs/suricata/suricata-4.1.0.yaml
+++ b/app/static/engine-configs/suricata/suricata-4.1.0.yaml
@@ -748,7 +748,7 @@ pcap-file:
   #  - auto: Suricata uses a statistical approach to detect when
   #  checksum off-loading is used. (default)
   # Warning: 'checksum-validation' must be set to yes to have checksum tested
-  checksum-checks: auto
+  checksum-checks: no
 
 # See "Advanced Capture Options" below for more options, including NETMAP
 # and PF_RING.


### PR DESCRIPTION
Depending on the pcap, the "auto" setting may not disable checksum verification when it should and can lead to packets not being properly identified.  For Dalton's use cases, we don't really care about checksum verification.