### PR TITLE
Updating python shared tag to handle missing repos

### DIFF
--- a/Dockerfile-dalton
+++ b/Dockerfile-dalton
@@ -1,4 +1,4 @@
-FROM python:2.7.14
+FROM python:2.7.16
 MAINTAINER David Wharton
 
 # wireshark needed for mergecap; statically compiled


### PR DESCRIPTION
The debian jessie repos used by python:2.7.14 are no longer available, see announcement [here](https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html). Proposing [python:2.7.16](https://github.com/docker-library/docs/blob/master/python/README.md) to provide debian stretch repos.