### PR TITLE
Install flowsynth with pip

### DIFF
--- a/Dockerfile-dalton
+++ b/Dockerfile-dalton
@@ -24,10 +24,11 @@ COPY rulesets /opt/dalton/rulesets
 COPY engine-configs /opt/dalton/engine-configs
 
 # install flowsynth
+
+# When a packaged version of flowsynth is available on https://pypi.org, then
+# flowsynth can be added to Dalton's requirements.txt file and this section
+# removed.
 RUN git clone https://github.com/secureworks/flowsynth.git /opt/flowsynth/
 RUN pip install /opt/flowsynth
-# When a packaged version of flowsynth is available on https://pypi.org, the
-# above two lines can be replaced with:
-# RUN pip install flowsynth
 
 CMD python /opt/dalton/run.py -c /opt/dalton/dalton.conf

--- a/Dockerfile-dalton
+++ b/Dockerfile-dalton
@@ -24,7 +24,7 @@ COPY rulesets /opt/dalton/rulesets
 COPY engine-configs /opt/dalton/engine-configs
 
 # install flowsynth
-RUN git clone -b add-packaging https://github.com/bac/flowsynth.git /opt/flowsynth/
+RUN git clone https://github.com/secureworks/flowsynth.git /opt/flowsynth/
 RUN pip install /opt/flowsynth
 # When a packaged version of flowsynth is available on https://pypi.org, the
 # above two lines can be replaced with:

--- a/Dockerfile-dalton
+++ b/Dockerfile-dalton
@@ -23,10 +23,11 @@ COPY dalton.conf /opt/dalton/dalton.conf
 COPY rulesets /opt/dalton/rulesets
 COPY engine-configs /opt/dalton/engine-configs
 
-#install flowsynth
-ADD https://github.com/secureworks/flowsynth/raw/master/requirements.txt /opt/flowsynth/requirements.txt
-ADD https://github.com/secureworks/flowsynth/raw/master/src/flowsynth.py /opt/flowsynth/src/flowsynth.py
-RUN pip install -r /opt/flowsynth/requirements.txt
-RUN chmod +x /opt/flowsynth/src/flowsynth.py
+# install flowsynth
+RUN git clone -b add-packaging https://github.com/bac/flowsynth.git /opt/flowsynth/
+RUN pip install /opt/flowsynth
+# When a packaged version of flowsynth is available on https://pypi.org, the
+# above two lines can be replaced with:
+# RUN pip install flowsynth
 
 CMD python /opt/dalton/run.py -c /opt/dalton/dalton.conf

--- a/app/flowsynth.py
+++ b/app/flowsynth.py
@@ -243,12 +243,12 @@ def compile_fs():
     fptr.close()
 
     #run the flowsynth command
-    command = "%s/src/flowsynth.py %s -f pcap -w %s --display json --no-filecontent" % (BIN_PATH, inpath, outpath)
+    command = "%s/src/flowsynth.py %s -f pcap -w %s --display json --no-filecontent" % (inpath, outpath)
     print command
     proc = subprocess.Popen(shlex.split(command), stdout = subprocess.PIPE, stderr = subprocess.PIPE)
     output = proc.communicate()[0]
 
-	#parse flowsynth json
+    #parse flowsynth json
     try:
         synthstatus = json.loads(output)
     except ValueError:


### PR DESCRIPTION
This branch installs flowsynth using pip.

- Removes dependency on knowing flowsynth's directory structure.
- Automatically installs flowsynth's dependencies.
- Paves the way from installing from a released wheel on https://pypi.org instead of pulling from github.

This work is dependent on https://github.com/secureworks/flowsynth/pull/14 landing.