### PR TITLE
Update coverage.html see full custom rule without scrolling.

### DIFF
--- a/app/templates/dalton/coverage.html
+++ b/app/templates/dalton/coverage.html
@@ -272,7 +272,7 @@
 								Use custom rules
 							</label>
 							<span id="custom_ruleset">
-								<textarea rows='10' cols='80' style='width: 1000px;' name="custom_ruleset" placeholder='alert tcp any any -> any any (msg:"";);'></textarea>
+								<textarea rows='10' cols='80' style='width: 100%;' name="custom_ruleset" placeholder='alert tcp any any -> any any (msg:"";);'></textarea>
 							</span>
 							<div style="display:block;width:100%;padding:0;margin-bottom:5px;margin-top:25px;font-size:21px;line-height:40px;color:#333;border:0;border-top:1px solid #e5e5e5">Logs</div>
 							<label class="checkbox">


### PR DESCRIPTION
Fixes custom rule text area requiring scroll.

width was hard-coded to 1000px, this sets it to 100% instead.