### PR TITLE
Speed up Zeek build

### DIFF
--- a/dalton-agent/Dockerfiles/Dockerfile_zeek
+++ b/dalton-agent/Dockerfiles/Dockerfile_zeek
@@ -11,7 +11,7 @@ WORKDIR /src
 ADD https://download.zeek.org/zeek-${ZEEK_VERSION}.tar.gz zeek-${ZEEK_VERSION}.tar.gz
 RUN tar -zxf zeek-${ZEEK_VERSION}.tar.gz -C zeek-${ZEEK_VERSION} --strip-components=1
 WORKDIR /src/zeek-${ZEEK_VERSION}
-RUN ./configure && make && make install
+RUN ./configure && make -j $(nproc) && make install
 
 env PATH /usr/local/zeek/bin/:$PATH
 


### PR DESCRIPTION
Speed up Zeek build on systems with multiple processing units by using simultaneous jobs when running 'make'.

As it is, building the Zeek container takes a long time, up to an hour or more of clock time.  This change reduces that to a fraction of what it was -- down to less than 10 mins on my system, although individual experience may be better or worse, depending on how many processing units the build system has, and the (processor) clock speed.