### PR TITLE
Update Dockerfile_suricata

### DIFF
--- a/dalton-agent/Dockerfiles/Dockerfile_suricata
+++ b/dalton-agent/Dockerfiles/Dockerfile_suricata
@@ -10,7 +10,7 @@ ARG ENABLE_RUST
 RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3.8 \
     tcpdump \
-    libpcre3 libpcre3-dbg libpcre3-dev libnss3-dev\
+    libpcre2-dev libpcre3 libpcre3-dbg libpcre3-dev libnss3-dev\
     build-essential autoconf automake libtool libpcap-dev libnet1-dev \
     libyaml-0-2 libyaml-dev zlib1g zlib1g-dev libcap-ng-dev libcap-ng0 \
     make libmagic-dev libjansson-dev libjansson4 pkg-config rustc cargo \


### PR DESCRIPTION
Fixes Suricata 7.x failing to compile due to missing libpcre2 library