### PR TITLE
Fix suricata container

### DIFF
--- a/dalton-agent/Dockerfiles/Dockerfile_suricata
+++ b/dalton-agent/Dockerfiles/Dockerfile_suricata
@@ -14,7 +14,7 @@ RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential autoconf automake libtool libpcap-dev libnet1-dev \
     libyaml-0-2 libyaml-dev zlib1g zlib1g-dev libcap-ng-dev libcap-ng0 \
     make libmagic-dev libjansson-dev libjansson4 pkg-config rustc cargo \
-    liblua5.1-dev libevent-dev
+    liblua5.1-dev libevent-dev libpcre2-dev
 
 
 # for debugging agent


### PR DESCRIPTION
Fixes issue where unable to build suricata container

```
checking for linux/landlock.h... no
[+] Building 0.0s (0/0)
yescking for plugin support...
checking checking if gcc supports -march=native... yes
checking for spatch... no
checking for zlib.h... yes
checking for inflate in -lz... yes
checking for pcre2_compile_8 in -lpcre2-8... no

   ERROR!  pcre2 library not found, go get it
   from www.pcre.org. Or from packages:
   Debian/Ubuntu: apt install libpcre2-dev
   Fedora: dnf install pcre2-devel
   CentOS/RHEL: yum install pcre2-devel
[+] Building 0.0s (0/0)
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -I/usr/include -Dyylval=sfbpf_lval -g -O2 -fvisibility=hidden -Wall -Wwrite-strings -Wsign-compare -Wcast-align -Wextra -Wformat -Wformat-security -Wno-unused-parameter -fno-strict-aliasing -fdiagnostics-show-option -pedantic -std=c99 -D_GNU_SOURCE -MT libsfbpf_la-sf_gencode.lo -MD -MP -MF .deps/libsfbpf_la[+] Building 0.0s (0/0)
[+] Building 0.0s (0/0)
```