### PR TITLE
Zeek Enhancements in Dalton

### DIFF
--- a/app/dalton.py
+++ b/app/dalton.py
@@ -1311,11 +1311,10 @@ def page_coverage_summary():
         if os.path.isfile(uiwrite_file_path):
             os.remove(uiwrite_file_path)
     bCustomscriptwrite = False
-    if checkbox_value:
-        if custom_script:
-            bCustomscriptwrite = True
-            with open(uiwrite_file_path, 'w') as file:
-                file.write(custom_script)
+    if checkbox_value and custom_script:
+        bCustomscriptwrite = True
+        with open(uiwrite_file_path, 'w') as file:
+            file.write(custom_script)
         
     bSplitCap = False
     try:

--- a/app/dalton.py
+++ b/app/dalton.py
@@ -65,6 +65,7 @@ try:
     dalton_config.read(dalton_config_filename)
     TEMP_STORAGE_PATH = dalton_config.get('dalton', 'temp_path')
     RULESET_STORAGE_PATH = dalton_config.get('dalton', 'ruleset_path')
+    SCRIPT_STORAGE_PATH = dalton_config.get('dalton', 'script_path')
     JOB_STORAGE_PATH = dalton_config.get('dalton', 'job_path')
     CONF_STORAGE_PATH = dalton_config.get('dalton', 'engine_conf_path')
     REDIS_EXPIRE = (dalton_config.getint('dalton', 'redis_expire') * 60)
@@ -1291,6 +1292,25 @@ def page_coverage_summary():
             delete_temp_files(job_id)
             return render_template('/dalton/error.html', jid='', msg=[err_msg])
         pcap_files.append({'filename': fspcap, 'pcappath': os.path.join(FS_PCAP_PATH, os.path.basename(fspcap))})
+    
+    #zeek-customscript
+    uiupload_file_path = os.path.join(SCRIPT_STORAGE_PATH, 'uiupload.zeek')
+    if os.path.isfile(uiupload_file_path):
+        os.remove(uiupload_file_path)
+
+    file = request.files.get("zeek-custom")
+    if file:
+        file.save(uiupload_file_path)
+
+    uiwrite_file_path = os.path.join(SCRIPT_STORAGE_PATH, 'uiwrite.zeek') 
+    checkbox_value = request.form.get("optionCustomScript")
+    if not checkbox_value:
+        if os.path.isfile(uiwrite_file_path):
+            os.remove(uiwrite_file_path)
+    if checkbox_value:
+        custom_script = request.form.get('custom_script', '')
+        with open(uiwrite_file_path, 'w') as file:
+            file.write(custom_script)
 
     bSplitCap = False
     try:

--- a/app/dalton.py
+++ b/app/dalton.py
@@ -1299,19 +1299,24 @@ def page_coverage_summary():
         os.remove(uiupload_file_path)
 
     file = request.files.get("zeek-custom")
+    bCustomscriptfile = False
     if file:
+        bCustomscriptfile = True
         file.save(uiupload_file_path)
 
     uiwrite_file_path = os.path.join(SCRIPT_STORAGE_PATH, 'uiwrite.zeek') 
     checkbox_value = request.form.get("optionCustomScript")
-    if not checkbox_value:
+    custom_script = request.form.get('custom_script', '')
+    if not checkbox_value or not custom_script:
         if os.path.isfile(uiwrite_file_path):
             os.remove(uiwrite_file_path)
+    bCustomscriptwrite = False
     if checkbox_value:
-        custom_script = request.form.get('custom_script', '')
-        with open(uiwrite_file_path, 'w') as file:
-            file.write(custom_script)
-
+        if custom_script:
+            bCustomscriptwrite = True
+            with open(uiwrite_file_path, 'w') as file:
+                file.write(custom_script)
+        
     bSplitCap = False
     try:
         if request.form.get("optionSplitcap"):
@@ -2075,6 +2080,8 @@ def page_coverage_summary():
                 json_job['override-external-net'] = bOverrideExternalNet
                 json_job['suricata-eve'] = bGetEveLog
                 json_job['zeek-json-logs'] = boptionZeekJSON
+                json_job['custom-script-file'] = bCustomscriptfile
+                json_job['custom-script-write'] = bCustomscriptwrite
                 # add var and other fields too
                 str_job = json.dumps(json_job)
 

--- a/app/dalton.py
+++ b/app/dalton.py
@@ -1299,8 +1299,9 @@ def page_coverage_summary():
         os.remove(uiupload_file_path)
 
     file = request.files.get("zeek-custom")
+    checkbox_value1 = request.form.get("optionCustomScriptfile")
     bCustomscriptfile = False
-    if file:
+    if file and checkbox_value1:
         bCustomscriptfile = True
         file.save(uiupload_file_path)
 

--- a/app/templates/dalton/coverage.html
+++ b/app/templates/dalton/coverage.html
@@ -440,7 +440,7 @@
                                 Write custom script
                             </label>
                             <span id="custom_script">
-                                <textarea rows='10' class='span'; style='margin-left:0;' name="custom_script" placeholder='event zeek_init() { print "Hello World!"; }'>{% if manifest and manifest['custom-script'] and custom_script %}{{custom_script}}{% endif %}</textarea>
+                                <textarea rows='10' class='span'; style='margin-left:0;' name="custom_script" placeholder='event zeek_init() { print "Hello World!"; }'>{% if custom_script %}{{custom_script}}{% endif %}</textarea>
                             </span>                        
                         {% endif %}
 						{% if not sensor_tech.startswith('zeek') %}

--- a/app/templates/dalton/coverage.html
+++ b/app/templates/dalton/coverage.html
@@ -33,30 +33,30 @@
         document.getElementById("versionHeading").innerHTML = newstr;
     }
     $(document).ready(function() {
-        function toggleCustomScript() {
+        function writeCustom_Script() {
             if ($('#optionScriptCustom').prop('checked')) {
                 $('#custom_script').show();
             } else {
                 $('#custom_script').hide();
             }
         }
-        toggleCustomScript();
+        writeCustom_Script();
         $('#optionScriptCustom').change(function() {
-            toggleCustomScript();
+            writeCustom_Script();
         });
     });
 
     $(document).ready(function() {
-        function toggleCustomScriptfile() {
+        function uploadCustom_Script_file() {
             if ($('#optionScriptCustomfile').prop('checked')) {
                 $('#custom_script_file').show();
             } else {
                 $('#custom_script_file').hide();
             }
         }
-        toggleCustomScriptfile();
+        uploadCustom_Script_file();
         $('#optionScriptCustomfile').change(function() {
-            toggleCustomScriptfile();
+            uploadCustom_Script_file();
         });
     });
 

--- a/app/templates/dalton/coverage.html
+++ b/app/templates/dalton/coverage.html
@@ -436,7 +436,7 @@
                             </span>
                             <br>
                             <label class="checkbox">
-                                <input type="checkbox" name="optionCustomScript" id="optionScriptCustom" value="script" {% if manifest and manifest['custom-script'] %} checked{% endif %}>
+                                <input type="checkbox" name="optionCustomScript" id="optionScriptCustom" value="script" {% if manifest and manifest['custom-script-write'] %} checked{% endif %}>
                                 Write custom script
                             </label>
                             <span id="custom_script">

--- a/app/templates/dalton/coverage.html
+++ b/app/templates/dalton/coverage.html
@@ -297,10 +297,10 @@
             console.debug("Version: " + version);
             var new_engine_conf = $.get("/dalton/controller_api/request_engine_conf?sensor=" + version, function( data ) {
                 if (data && data != '') {
-                    document.getElementById('custom_engineconf_t').value = data;
-                    updateHeading(version);
+                    document.getElementById('custom_engineconf_t').value = data;        
                 }
             });
+            updateHeading(version);
             show_hide_log_options(version);
             show_hide_suricatasc_options(version);
         });

--- a/app/templates/dalton/coverage.html
+++ b/app/templates/dalton/coverage.html
@@ -32,6 +32,39 @@
         }
         document.getElementById("versionHeading").innerHTML = newstr;
     }
+    $(document).ready(function() {
+        function toggleCustomScript() {
+            if ($('#optionScriptCustom').prop('checked')) {
+                $('#custom_script').show();
+            } else {
+                $('#custom_script').hide();
+            }
+        }
+        toggleCustomScript();
+        $('#optionScriptCustom').change(function() {
+            toggleCustomScript();
+        });
+    });
+
+    $(document).ready(function() {
+        function toggleCustomScriptfile() {
+            if ($('#optionScriptCustomfile').prop('checked')) {
+                $('#custom_script_file').show();
+            } else {
+                $('#custom_script_file').hide();
+            }
+        }
+        toggleCustomScriptfile();
+        $('#optionScriptCustomfile').change(function() {
+            toggleCustomScriptfile();
+        });
+    });
+
+    $(document).ready(function() {
+        $('#resetscript').click(function() {
+          $('#zeek-custom').val('');
+        });
+    });
 
 	$(document).ready(function() {
 		$('#prod_ruleset').show();
@@ -386,7 +419,30 @@
                                         Use Suricata Socket Control Pcap Processing Mode
                                     </label>
                                 </div>
-
+                        {% if sensor_tech.startswith('zeek') %}
+                            <div style="display:block;width:100%;padding:0;margin-bottom:5px;margin-top:25px;font-size:21px;line-height:40px;color:#333;border:0;border-top:1px solid #e5e5e5">
+                                Custom Scripts
+                            </div>
+                            <label class="checkbox">
+                                <input type="checkbox" name="optionCustomScriptfile" id="optionScriptCustomfile" value="scriptfile" {% if manifest and manifest['custom-script-file'] %} checked{% endif %}>
+                                Upload custom script file
+                            </label>
+                            <span id="custom_script_file">
+                                <input type="file" name="zeek-custom" id="zeek-custom" placeholder="Select a script" accept=".zeek">
+                                <p></p>
+                                <div id="resetscript">
+                                    <a href="#">Reset Script</a>
+                                </div>
+                            </span>
+                            <br>
+                            <label class="checkbox">
+                                <input type="checkbox" name="optionCustomScript" id="optionScriptCustom" value="script" {% if manifest and manifest['custom-script'] %} checked{% endif %}>
+                                Write custom script
+                            </label>
+                            <span id="custom_script">
+                                <textarea rows='10' class='span'; style='margin-left:0;' name="custom_script" placeholder='event zeek_init() { print "Hello World!"; }'>{% if manifest and manifest['custom-script'] and custom_script %}{{custom_script}}{% endif %}</textarea>
+                            </span>                        
+                        {% endif %}
 						{% if not sensor_tech.startswith('zeek') %}
 							<div style="display:block;width:100%;padding:0;margin-bottom:5px;margin-top:25px;font-size:21px;line-height:40px;color:#333;border:0;border-top:1px solid #e5e5e5">Ruleset</div>
 							<label class="checkbox">

--- a/dalton-agent/Dockerfiles/Dockerfile_zeek
+++ b/dalton-agent/Dockerfiles/Dockerfile_zeek
@@ -2,10 +2,38 @@ FROM ubuntu:20.04
 
 ARG ZEEK_VERSION
 
-RUN apt-get update --fix-missing -y && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-	tcpdump cmake make gcc g++ flex bison libpcap-dev libssl-dev python3.8 python3.8-dev swig zlib1g-dev
+# Set non-interactive frontend to avoid interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
 
-# download, build, and install Zeek from source
+# Update package list and install required packages including Node.js and Python
+RUN apt-get update --fix-missing -y && \
+    apt-get install -y \
+        curl \
+        gnupg \
+        build-essential \
+        tcpdump \
+        cmake \
+        make \
+        gcc \
+        g++ \
+        flex \
+        bison \
+        libpcap-dev \
+        libssl-dev \
+        python3 \
+        python3-dev \
+        python3-pip \
+        swig \
+        zlib1g-dev \
+        && \
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs \
+    && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/usr/local/zeek/bin/:${PATH}"
+
 RUN mkdir -p /src/zeek-${ZEEK_VERSION}
 WORKDIR /src
 ADD https://download.zeek.org/zeek-${ZEEK_VERSION}.tar.gz zeek-${ZEEK_VERSION}.tar.gz
@@ -13,11 +41,10 @@ RUN tar -zxf zeek-${ZEEK_VERSION}.tar.gz -C zeek-${ZEEK_VERSION} --strip-compone
 WORKDIR /src/zeek-${ZEEK_VERSION}
 RUN ./configure && make -j $(nproc) && make install
 
-env PATH /usr/local/zeek/bin/:$PATH
-
 RUN mkdir -p /opt/dalton-agent/
 WORKDIR /opt/dalton-agent
 COPY dalton-agent.py /opt/dalton-agent/dalton-agent.py
 COPY dalton-agent.conf /opt/dalton-agent/dalton-agent.conf
 
-CMD python3.8 /opt/dalton-agent/dalton-agent.py -c /opt/dalton-agent/dalton-agent.conf 2>&1
+# Set the default command to run the application
+CMD ["python3", "/opt/dalton-agent/dalton-agent.py", "-c", "/opt/dalton-agent/dalton-agent.conf"]

--- a/dalton-agent/dalton-agent.py
+++ b/dalton-agent/dalton-agent.py
@@ -170,7 +170,12 @@ def get_engine_version(path):
     engine = "unknown"
     version = "unknown"
     try:
-        process = subprocess.Popen("%s -V" % path, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        binary_name = os.path.basename(path).lower()
+        if 'zeek' in binary_name:
+            command = f"{path} --version"
+        elif 'snort' in binary_name or 'suricata' in binary_name:
+            command = f"{path} -V"
+        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         stdout, stderr = process.communicate()
         regex = re.compile(r"(Version|(Suricata|zeek) version)\s+(?P<version>\d+[\d\x2E\x2D\5FA-Za-z]*)")
         if stderr:

--- a/dalton.conf
+++ b/dalton.conf
@@ -13,6 +13,9 @@ job_path = /opt/dalton/jobs
 # it is not recommended that you change this
 ruleset_path = /opt/dalton/rulesets
 
+# directory for the zeek scripts
+script_path = /opt/dalton/rulesets/zeek/
+
 # temp storage for pcaps, configs, etc. Should be cleaned up by Dalton 
 #  and everything in here can be deleted after the job is submitted
 temp_path = /tmp/dalton

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -423,9 +423,21 @@ services:
       context: ./dalton-agent
       dockerfile: Dockerfiles/Dockerfile_zeek
       args:
-        - ZEEK_VERSION=4.0.2
+        - ZEEK_VERSION=7.0.1
     image: zeek-current:latest
     container_name: zeek-current
+    volumes:
+      - ./rulesets/zeek:/opt/dalton-agent/zeek_scripts:ro
+    restart: always
+
+  agent-zeek-6.0.6:
+    build:
+      context: ./dalton-agent
+      dockerfile: Dockerfiles/Dockerfile_zeek
+      args:
+        - ZEEK_VERSION=6.0.6
+    image: zeek-6.0.6
+    container_name: zeek-6.0.6
     volumes:
       - ./rulesets/zeek:/opt/dalton-agent/zeek_scripts:ro
     restart: always


### PR DESCRIPTION
Add zeek version 7 and version 6 ; remove zeek version 4.

Dalton UI now will have an option to provide custom zeek script in zeek sensor job creation page. You can either upload custom script file or write the script (or both) in the Dalton UI, and can run pcaps using those custom scripts.

[Zeek custom script Enhancement in Dalton.pdf](https://github.com/user-attachments/files/16968658/Zeek.custom.script.Enhancement.in.Dalton.pdf)

closes #175 
closes #176 