### PR TITLE
Update nginx

### DIFF
--- a/Dockerfile-dalton
+++ b/Dockerfile-dalton
@@ -28,4 +28,4 @@ COPY engine-configs /opt/dalton/engine-configs
 STOPSIGNAL SIGINT
 EXPOSE 8080
 
-CMD python /opt/dalton/run.py -c /opt/dalton/dalton.conf
+CMD ["python", "/opt/dalton/run.py", "-c", "/opt/dalton/dalton.conf"]

--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -1,9 +1,8 @@
 # spin up nginx with custom conf
-FROM nginx:1.19.4
-MAINTAINER David Wharton
+FROM nginx:1.27.2
 
-ARG DALTON_EXTERNAL_PORT
-ARG DALTON_EXTERNAL_PORT_SSL
+ARG DALTON_EXTERNAL_PORT=80
+ARG DALTON_EXTERNAL_PORT_SSL=443
 
 RUN rm /etc/nginx/nginx.conf && rm -rf /etc/nginx/conf.d
 COPY nginx-conf/nginx.conf /etc/nginx/nginx.conf
@@ -13,6 +12,5 @@ COPY nginx-conf/tls /etc/nginx/tls
 # adjust nginx config so redirects point to external port(s).
 # order of sed operations matters since one replaced string is a subset of the other.
 RUN sed -i 's/REPLACE_AT_DOCKER_BUILD_SSL/'"${DALTON_EXTERNAL_PORT_SSL}"'/' /etc/nginx/conf.d/dalton.conf
+# hadolint ignore=DL3059
 RUN sed -i 's/REPLACE_AT_DOCKER_BUILD/'"${DALTON_EXTERNAL_PORT}"'/' /etc/nginx/conf.d/dalton.conf
-
-CMD nginx

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,6 @@ lint:
 fix:
 	.venv/bin/ruff format
 	.venv/bin/ruff check --fix
+
+hadolint: Dockerfile-dalton Dockerfile-nginx
+	docker run -t --rm -v `pwd`:/app -w /app hadolint/hadolint /bin/hadolint $^

--- a/nginx-conf/nginx.conf
+++ b/nginx-conf/nginx.conf
@@ -2,7 +2,6 @@ user www-data;
 worker_processes 1;
 error_log /var/log/nginx/error.log;
 pid /run/nginx.pid;
-daemon off;
 
 events {
     worker_connections 1024;


### PR DESCRIPTION
Issue #200 

- go from nginx 1.19 to 1.27
- Added a Makefile target to lint the Dockerfiles
- The default nginx docker image has a `CMD` of `["nginx" "-g" "daemon off;"]` so
  - we don't need the CMD in our Dockerfile
  - and we can't have "daemon off" in our nginx config
