### PR TITLE
Use ruff to sort imports

### DIFF
--- a/api/dalton.py
+++ b/api/dalton.py
@@ -1,10 +1,9 @@
 """Dalton API client."""
 
-import requests
 import time
 
+import requests
 from requests.exceptions import HTTPError
-
 
 RETRIES = 3
 SLEEP_TIME = 60

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,11 +1,12 @@
+import logging
 import os
 
 from flask import Flask
 from flask_caching import Cache
 from flask_compress import Compress
+
 from app.dalton import dalton_blueprint, ensure_rulesets_exist, setup_dalton_logging
 from app.flowsynth import flowsynth_blueprint, setup_flowsynth_logging
-import logging
 
 
 def create_app(test_config=None):

--- a/app/certsynth.py
+++ b/app/certsynth.py
@@ -1,6 +1,6 @@
-import struct
 import binascii
 import re
+import struct
 
 SYNTH_START = """
 ## Client Hello

--- a/app/dalton.py
+++ b/app/dalton.py
@@ -17,34 +17,35 @@ Dalton - a UI and management tool for submitting and viewing IDS jobs
 # limitations under the License.
 
 # app imports
-from flask import Blueprint, render_template, request, Response, redirect, url_for
+import base64
+import bz2
+import configparser
+import copy
+import datetime
+import glob
+import gzip
 
 # from flask_login import current_user
 import hashlib
-import os
-import glob
-import re
-import redis
-import datetime
-import time
 import json
-import zipfile
-import tarfile
-import gzip
-import bz2
-import shutil
-from distutils.version import LooseVersion
-import configparser
 import logging
-from logging.handlers import RotatingFileHandler
-import subprocess
-from ruamel import yaml
-import base64
-import traceback
+import os
 import random
-from threading import Thread
+import re
+import shutil
+import subprocess
+import tarfile
 import tempfile
-import copy
+import time
+import traceback
+import zipfile
+from distutils.version import LooseVersion
+from logging.handlers import RotatingFileHandler
+from threading import Thread
+
+import redis
+from flask import Blueprint, Response, redirect, render_template, request, url_for
+from ruamel import yaml
 
 # setup the dalton blueprint
 dalton_blueprint = Blueprint(

--- a/dalton-agent/dalton-agent.py
+++ b/dalton-agent/dalton-agent.py
@@ -27,33 +27,30 @@ Dalton Agent - runs on IDS engine; receives jobs, runs them, and reports results
 # still present.
 #
 
-import os
-import sys
-import traceback
-import urllib.request
-import urllib.parse
-import urllib.error
-import urllib.request
-import urllib.error
-import urllib.parse
-import re
-import time
+import base64
+import binascii
+import configparser
 import datetime
 import glob
-import shutil
-import base64
-import json
-import subprocess
-import zipfile
-import configparser
-from optparse import OptionParser
-import struct
-import socket
-import logging
-from logging.handlers import RotatingFileHandler
-from distutils.version import LooseVersion
-import binascii
 import hashlib
+import json
+import logging
+import os
+import re
+import shutil
+import socket
+import struct
+import subprocess
+import sys
+import time
+import traceback
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from distutils.version import LooseVersion
+from logging.handlers import RotatingFileHandler
+from optparse import OptionParser
 from pathlib import Path
 
 # urllib2 in Python < 2.6 doesn't support setting a timeout so doing it like this

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,11 @@ include = [
     "tests/**/*.py"
 ]
 exclude = ["app/static/**/*.py"]
+
+[tool.ruff.lint]
+# see https://docs.astral.sh/ruff/rules/#legend
+# E = errors, F = pyflakes, I = isort
+select = ["E", "F", "I"]
+# ignore D203 because it conflicts with D211
+# ignore D213 because it conflicts with D212
+ignore = ["D203", "D213", "E501"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 from app import create_app
 
 

--- a/tests/test_flowsynth.py
+++ b/tests/test_flowsynth.py
@@ -1,25 +1,20 @@
-import pytest
-import unittest
-
-
-from unittest import mock
-
-import random
-
 import os
+import random
 import shutil
+import unittest
 import uuid
 from io import BytesIO
+from unittest import mock
 from urllib.parse import urlencode
 
+import pytest
 
 from app.flowsynth import (
-    unicode_safe,
     check_pcap_path,
     get_pcap_file_path,
     get_pcap_path,
+    unicode_safe,
 )
-
 
 KNOWN_PCAP_ID = "98765"
 KNOWN_PCAP_CONTENTS = b"hi there"


### PR DESCRIPTION
- Use `tool.ruff.lint` setting in pyproject.toml
- Ran `make fix` to fix the isort

Closes #207