### PR TITLE
Use bump-my-version tool to help with versioning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -149,8 +149,11 @@ Zeek Enhancements (#177)
 
 Author: Nikhileswar Reddy <nreddy@octolabs.io>
 
-4.0.0
+3.4.0 (2024-11-12)
 ##################
+
+Version 3.4.x is available initially on the pilot branch,
+in a sort of pre-release mode.
 
 * Use pyproject.toml (#184) (#189)
 * Use ruff format to format the code (#183) (#190)
@@ -163,3 +166,6 @@ Author: Nikhileswar Reddy <nreddy@octolabs.io>
 * Use ruff to sort and format imports (#207)
 * Use ruff to detect flake8 bugbears (B) (#209)
 * Use pre-built zeek images (#181)
+* Use bump-my-version to update the version and tag (#197)
+  * Also, use bump-my-version to update the dalton-agent version
+  * Also, show the dalton controller version on the About page

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ PYTEST=$(VENV)/bin/pytest
 COVERAGE=$(VENV)/bin/coverage
 RUFF=$(VENV)/bin/ruff
 ACTIVATE=$(VENV)/bin/activate
-
+BUMPVERSION=$(VENV)/bin/bump-my-version
+BUMPPART ?= patch
 
 venv $(VENV):
 	python3 -m venv $(VENV)
@@ -30,3 +31,9 @@ fix: $(VENV)
 
 hadolint: Dockerfile-dalton Dockerfile-nginx dalton-agent/Dockerfiles/Dockerfile_*
 	docker run -t --rm -v `pwd`:/app -w /app hadolint/hadolint /bin/hadolint $^
+
+bumpversion: $(VENV) pyproject.toml
+	$(BUMPVERSION) bump $(BUMPPART)
+
+bumpagent: $(VENV) pyproject.toml
+	$(BUMPVERSION) bump --config-file dalton-agent/.bumpversion.toml $(BUMPPART)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,7 +8,7 @@ from flask_compress import Compress
 from app.dalton import dalton_blueprint, ensure_rulesets_exist, setup_dalton_logging
 from app.flowsynth import flowsynth_blueprint, setup_flowsynth_logging
 
-__version__ = "3.3.6"
+__version__ = "3.4.0"
 
 def create_app(test_config=None):
     """Create the flask app."""

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -8,6 +8,7 @@ from flask_compress import Compress
 from app.dalton import dalton_blueprint, ensure_rulesets_exist, setup_dalton_logging
 from app.flowsynth import flowsynth_blueprint, setup_flowsynth_logging
 
+__version__ = "3.3.6"
 
 def create_app(test_config=None):
     """Create the flask app."""

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,6 +10,7 @@ from app.flowsynth import flowsynth_blueprint, setup_flowsynth_logging
 
 __version__ = "3.4.0"
 
+
 def create_app(test_config=None):
     """Create the flask app."""
     curdir = os.path.dirname(os.path.abspath(__file__))

--- a/app/dalton.py
+++ b/app/dalton.py
@@ -3071,7 +3071,7 @@ def page_queue_default():
 # @login_required()
 def page_about_default():
     """the about/help page"""
-    return render_template("/dalton/about.html", page="")
+    return render_template("dalton/about.html", version=app.__version__)
 
 
 #########################################

--- a/app/dalton.py
+++ b/app/dalton.py
@@ -3071,6 +3071,9 @@ def page_queue_default():
 # @login_required()
 def page_about_default():
     """the about/help page"""
+    # Need to `import app` here, not at the top of the file.
+    import app
+
     return render_template("dalton/about.html", version=app.__version__)
 
 

--- a/app/templates/dalton/about.html
+++ b/app/templates/dalton/about.html
@@ -3,4 +3,5 @@
     <h1>About Dalton</h1>
     <p>Dalton allows pcaps to be run against sundry IDS sensors (e.g. Suricata, Snort) and sensor versions using a defined ruleset and/or bespoke rules.</p>
     <p>Official repository and documentation can be found at <a href="https://github.com/secureworks/dalton">https://github.com/secureworks/dalton</a></p>
+    <p>This is Dalton version {{ version }}</p>
 {% endblock %}

--- a/dalton-agent/.bumpversion.toml
+++ b/dalton-agent/.bumpversion.toml
@@ -1,0 +1,21 @@
+[tool.bumpversion]
+current_version = "3.1.1"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
+serialize = ["{major}.{minor}.{patch}"]
+search = "{current_version}"
+replace = "{new_version}"
+regex = false
+ignore_missing_version = false
+ignore_missing_files = false
+tag = false
+sign_tags = false
+allow_dirty = false
+commit = true
+message = "Bump dalton-agent version: {current_version} → {new_version}"
+commit_args = "--no-verify"
+setup_hooks = []
+pre_commit_hooks = []
+post_commit_hooks = []
+
+[[tool.bumpversion.files]]
+filename = "dalton-agent/dalton-agent.py"

--- a/dalton-agent/.bumpversion.toml
+++ b/dalton-agent/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "3.1.1"
+current_version = "3.1.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/dalton-agent/dalton-agent.py
+++ b/dalton-agent/dalton-agent.py
@@ -282,7 +282,7 @@ def hash_file(filenames):
 # *** Constant Variables ***
 # **************************
 
-AGENT_VERSION = "3.1.1"
+AGENT_VERSION = "3.1.2"
 HTTP_HEADERS = {"User-Agent": f"Dalton Agent/{AGENT_VERSION}"}
 
 # check options from config file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ ignore = ["E501"]
 "dalton-agent/dalton-agent.py" = ["B"]
 
 [tool.bumpversion]
-current_version = "3.3.6"
+current_version = "3.4.0"
 
 commit = true
 allow_dirty = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dalton"
-version = "4.0.0"
 description = "Run pcaps against an IDS"
+dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
     "Jinja2==3.0.3",
@@ -43,8 +43,9 @@ testing = [
     "pytest",
 ]
 devtools = [
-    "ruff",
+    "bump-my-version",
     "coverage",
+    "ruff",
 ]
 
 [tool.pytest.ini_options]
@@ -75,3 +76,19 @@ ignore = ["E501"]
 [tool.ruff.lint.per-file-ignores]
 # Defer these fixes to dalton-agent until we have some unit tests
 "dalton-agent/dalton-agent.py" = ["B"]
+
+[tool.bumpversion]
+current_version = "3.3.6"
+
+commit = true
+allow_dirty = false
+message = "Bump version: {current_version} → {new_version}"
+commit_args = "--no-verify"
+
+tag = true
+sign_tags = false
+tag_name = "v{new_version}"
+tag_message = "Bump version: {current_version} → {new_version}"
+
+[[tool.bumpversion.files]]
+filename = "app/__init__.py"


### PR DESCRIPTION
- The dalton `about` page now shows the controller version
- New makefile target: `make bumpversion`, updates the version and tags the repo
- New makefile target: `make bumpagent`, updates the agent version but does not tag the repo

Closes #197 