### PR TITLE
Ubuntu 24.04 containers for Suricata (4.x and newer) and Snort (2.9.16.x and newer)

### DIFF
--- a/dalton-agent/Dockerfiles/Dockerfile_snort
+++ b/dalton-agent/Dockerfiles/Dockerfile_snort
@@ -1,26 +1,25 @@
 # Builds Snort 2.9.x.x Dalton agent using Snort source
-# Works for Snort 2.9.1.1 and later; previous versions are more
-#  nuanced with libraries and compile dependencies so if you need
-#  a previous version, just build your own.
-
+# Works for Snort 2.9.16.x and later
 # hadolint global ignore=DL3003,SC2046
 
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
 ARG SNORT_VERSION
 ARG DAQ_VERSION
 
 # tcpdump is for pcap analysis; not *required* for
 #  the agent but nice to have....
+# changed python3.8 to python3 python3-dev python3-pip
+# other additional packages: libtool libtirpc-dev
 # hadolint ignore=DL3008
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    python3.8 \
+    python3 python3-dev python3-pip \
     tcpdump \
-    automake autoconf \
+    automake libtool autoconf \
     build-essential make flex bison \
     libpcap-dev libpcre3-dev \
-    libcap-ng-dev libdumbnet-dev \
+    libcap-ng-dev libdumbnet-dev libtirpc-dev \
     zlib1g-dev liblzma-dev openssl libssl-dev \
     libnghttp2-dev libluajit-5.1-dev && \
     ldconfig && \
@@ -34,12 +33,14 @@ RUN apt-get update -y && \
 RUN mkdir -p /src/snort-${SNORT_VERSION} && mkdir -p /etc/snort
 WORKDIR /src
 # DAQ.  Apparently DAQ will sometime fail building with multiple make jobs.
+# Discovered that autoreconf is necessary to avoid failures compiling DAQ on 24.04
 ADD https://www.snort.org/downloads/archive/snort/daq-${DAQ_VERSION}.tar.gz daq-${DAQ_VERSION}.tar.gz
-RUN tar -zxf daq-${DAQ_VERSION}.tar.gz && cd daq-${DAQ_VERSION} && ./configure && make && make install
+RUN tar -zxf daq-${DAQ_VERSION}.tar.gz && cd daq-${DAQ_VERSION} && autoreconf -f -i && ./configure && make && make install
 # Snort
+# Necessary to add CFLAGS="-I/usr/include/tirpc" to point snort to the correctly location for the RPC headers it needs
 ADD https://www.snort.org/downloads/archive/snort/snort-${SNORT_VERSION}.tar.gz snort-${SNORT_VERSION}.tar.gz
 RUN tar -zxf snort-${SNORT_VERSION}.tar.gz -C snort-${SNORT_VERSION} --strip-components=1 && \
-    cd /src/snort-${SNORT_VERSION} && ./configure --enable-sourcefire --enable-debug --enable-buffer-dump && make -j $(nproc) && make install && \
+    cd /src/snort-${SNORT_VERSION} && ./configure --enable-sourcefire --enable-debug --enable-buffer-dump CFLAGS="-I/usr/include/tirpc" && make -j $(nproc) && make install && \
     mkdir /usr/local/lib/snort_dynamicrules && ldconfig
 
 RUN cp -t /etc/snort/ /src/snort-${SNORT_VERSION}/etc/classification.config /src/snort-${SNORT_VERSION}/etc/file_magic.conf \
@@ -51,4 +52,4 @@ WORKDIR /opt/dalton-agent
 COPY dalton-agent.py /opt/dalton-agent/dalton-agent.py
 COPY dalton-agent.conf /opt/dalton-agent/dalton-agent.conf
 
-CMD ["python3.8", "/opt/dalton-agent/dalton-agent.py", "-c", "/opt/dalton-agent/dalton-agent.conf"]
+CMD ["python3", "/opt/dalton-agent/dalton-agent.py", "-c", "/opt/dalton-agent/dalton-agent.conf"]

--- a/dalton-agent/Dockerfiles/Dockerfile_suricata
+++ b/dalton-agent/Dockerfiles/Dockerfile_suricata
@@ -1,5 +1,5 @@
 # Builds Suricata Dalton agent using Suricata source tarball
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
 ARG SURI_VERSION
 ARG ENABLE_RUST
@@ -7,9 +7,10 @@ ARG ENABLE_RUST
 # tcpdump is for pcap analysis; not *required* for
 #  the agent but nice to have....
 # hadolint ignore=DL3008
+# changing the python3.8 package to python3 python3-dev and python3-pip
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    python3.8 \
+    python3 python3-dev python3-pip \
     tcpdump \
     libpcre3 libpcre3-dbg libpcre3-dev libnss3-dev \
     build-essential autoconf automake libtool libpcap-dev libnet1-dev \
@@ -52,4 +53,4 @@ COPY tls.lua /opt/dalton-agent/tls.lua
 
 RUN sed -i 's/REPLACE_AT_DOCKER_BUILD-VERSION/'"${SURI_VERSION}"'/' /opt/dalton-agent/dalton-agent.conf
 
-CMD ["python3.8", "/opt/dalton-agent/dalton-agent.py", "-c", "/opt/dalton-agent/dalton-agent.conf"]
+CMD ["python3", "/opt/dalton-agent/dalton-agent.py", "-c", "/opt/dalton-agent/dalton-agent.conf"]

--- a/dalton-agent/Dockerfiles/Dockerfile_suricata
+++ b/dalton-agent/Dockerfiles/Dockerfile_suricata
@@ -6,8 +6,8 @@ ARG ENABLE_RUST
 
 # tcpdump is for pcap analysis; not *required* for
 #  the agent but nice to have....
-# hadolint ignore=DL3008
 # changing the python3.8 package to python3 python3-dev and python3-pip
+# hadolint ignore=DL3008
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     python3 python3-dev python3-pip \


### PR DESCRIPTION
Greetings!

This PR is to address #199 

Here is a summary of changes:

## Dockerfile_suricata:

 - `FROM ubuntu:24.04` in order to use Ubuntu 24.04 as the base container image
 - Changed python3.8 package and instead acquires `python3`, `python3-dev`, and `python3-pip` to mirror the packages pulled for the zeek container
 - Final CMD that launches `dalton-agent.py` uses `python3` instead of `python3.8` to run the agent.
 - **Tested and Confirmed to work for Suricata versions 4.1.0 and above successfully**
 
 ## Dockerfile_snort:

 - `FROM ubuntu:24.04` in order to use Ubuntu 24.04 as the base container image
 - Changed python3.8 package and instead acquires `python3`, `python3-dev`, and `python3-pip` to mirror the packages pulled for the zeek container
 - Additional new packages acquired via `apt-get`: `libtool` `libtirpc-dev`
 - Added `autoreconf -f -i` to the `./configure && make && make install` command chain to avoid a failure to compile the DAQ libraries
 - Appended `CFLAGS="-I/usr/include/tirpc"` to Snort's `./configure` command. This was necessary because by default Snort tries to look for the RPC headers in `/usr/include/rpc`. This is no longer correct, so we have to point to the new location of the RPC headers (`/usr/include/tirpc`) for snort to compile successfully)
 - Final CMD that launches `dalton-agent.py` uses `python3` instead of `python3.8` to run the agent.
 - **Tested and confirmed to work for Snort versions 2.9.16.x and above successfully**