### PR TITLE
Add cyberchef container, nginx location, and link in layout.html

### DIFF
--- a/app/templates/dalton/layout.html
+++ b/app/templates/dalton/layout.html
@@ -68,6 +68,7 @@
                     <li><a href="/dalton/sensor" id='sensor-toggle'><i class="icon-hdd"></i>Sensors&nbsp;</a></li>
                 {% endif %}
                 <li><a href="/flowsynth/" id='flowsynth-toggle'><i class="icon-wrench"></i>Flowsynth</a></li>
+                <li><a href="/cyberchef" id='cyberchef-toggle'><i class="icon-food"></i>Cyberchef</a></li>
                 {% if (request.url_rule|string).endswith("/about") %}
                     <li class="active"><a href="/dalton/about" id="about-toggle"><i class="icon-info-sign"></i>About</a></li>
                 {% else %}

--- a/app/templates/dalton/layout.html
+++ b/app/templates/dalton/layout.html
@@ -68,7 +68,7 @@
                     <li><a href="/dalton/sensor" id='sensor-toggle'><i class="icon-hdd"></i>Sensors&nbsp;</a></li>
                 {% endif %}
                 <li><a href="/flowsynth/" id='flowsynth-toggle'><i class="icon-wrench"></i>Flowsynth</a></li>
-                <li><a href="/cyberchef" id='cyberchef-toggle'><i class="icon-food"></i>Cyberchef</a></li>
+                <li><a href="/cyberchef" id='cyberchef-toggle'><i class="icon-book"></i>Cyberchef</a></li>
                 {% if (request.url_rule|string).endswith("/about") %}
                     <li class="active"><a href="/dalton/about" id="about-toggle"><i class="icon-info-sign"></i>About</a></li>
                 {% else %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -448,3 +448,13 @@ services:
       - ./rulesets/zeek:/opt/dalton-agent/zeek_scripts:ro
     restart: always
 
+###########################
+## Cyberchef Integration ##
+###########################
+
+# Official cyberchef docker image, from github container repo (ghcr)
+  cyberchef:
+    image: ghcr.io/gchq/cyberchef:latest
+    container_name: cyberchef_current
+    hostname: cyberchef_current
+    restart: always

--- a/nginx-conf/conf.d/dalton.conf
+++ b/nginx-conf/conf.d/dalton.conf
@@ -15,6 +15,10 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+    location /cyberchef/ {
+        resolver 127.0.0.11;
+        proxy_pass http://cyberchef_current/;
+    }
 }
 
 server {
@@ -38,6 +42,10 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /cyberchef/ {
+        resolver 127.0.0.11;
+        proxy_pass http://cyberchef_current/;
     }
 }
 


### PR DESCRIPTION
Hello again,

This is another pull request, intended to address #229 

Here are the Changes I am proposing:

## dalton/docker-compose.yml

- Added an entry for "cyberchef_current"
  - image is based off of `ghcr.io/gchq/cyberchef:latest`
  - the official cyberchef docker image, directly from GCHQ, hosted on github container repository

## dalton/nginx-conf/conf.d/dalton.conf

- Added a location directive for both the port 80 and port 443 listener for `/cyberchef/`
  - includes `resolve 127.0.0.11;` to use docker's internal DNS to resolve the hostname `cyberchef_current` -- this is _very_ important.
  - includes `proxy_pass http://cyberchef_current/;` to redirect users to the cyberchef instance correctly
  - in my testing, none of the `proxy_set_header` directives were required to interact with cyberchef.

## dalton/app/templates/dalton/layout.html

 - Added a list item and link to /cyberchef that becomes a clickable link on the navigation bar
 - It was initially proposed to use `icon-food` for cyberchef. I agree this would look great, however, `icon-food` is NOT available in `dalton/app/static/bootstrap/img/glyphicons-halflings.png`. According font-awesome, this icon was added with version 3.0 (https://origin.fontawesome.com/v3/icon/food). I have opted to use `icon-book` instead (menu? recipe book?), but `icon-share` might be an option as well.
 
## Results:

The end-product: 
 
![image](https://github.com/user-attachments/assets/4054c8a1-a725-4521-86a1-ba6e94759b44)

When the Cyberchef button is clicked:

![image](https://github.com/user-attachments/assets/b3b44762-bbec-412b-96be-020341c8dc5b)

The landing page for cyber chef becomes accessible.
 